### PR TITLE
Fix timesync service

### DIFF
--- a/scripts/px4_set_time.sh
+++ b/scripts/px4_set_time.sh
@@ -12,4 +12,14 @@ if [[ $output != *"Successfully set system time"* ]]; then
 fi
 
 echo "Successfully set system time"
-echo "output: $output"
+echo "response: $output"
+
+# never exit, hack to allow restarting w/ mavlink-router
+tail -f
+
+# journalctl -b -f \
+#     -u systemd-timesyncd.service \
+#     -u systemd-time-wait-sync.service \
+#     -u time-sync.target \
+#     -u mavlink-router.service \
+#     -u px4-time.service

--- a/scripts/px4_shell_command.py
+++ b/scripts/px4_shell_command.py
@@ -115,7 +115,7 @@ def main():
     # Send heartbeat so that mavlink-router will route data back to us
     mav_serialport.mav.mav.heartbeat_send(mavutil.mavlink.MAV_TYPE_GCS, mavutil.mavlink.MAV_AUTOPILOT_GENERIC, 0, 0, 0)
 
-    mav_serialport.write('\n') # make sure the shell is started
+    mav_serialport.write('\n\n\n') # make sure the shell is started
     mav_serialport.read(4096)
 
     mav_serialport.write(args.command + '\n')

--- a/services/px4-time.service
+++ b/services/px4-time.service
@@ -2,10 +2,10 @@
 Description=Sets the time in UTC on PX4
 Wants=network.target
 Requires=mavlink-router.service
-After=syslog.target network-online.target mavlink-router.service
+After=syslog.target network-online.target time-sync.target mavlink-router.service
 
 [Service]
-Type=oneshot
+Type=exec
 ExecStart=/usr/bin/px4_set_time.sh
 Restart=on-failure
 RestartSec=5

--- a/setup.sh
+++ b/setup.sh
@@ -65,3 +65,9 @@ for service in ${service_list[@]}; do
 	echo "Starting $service"
 	sudo systemctl enable $service && sudo systemctl start $service
 done
+
+# Enable the time-sync service
+sudo systemctl enable systemd-time-wait-sync.service
+
+# Add some helpful aliases
+echo "alias mavshell=\"mavlink_shell.py udp:0.0.0.0:14569\"" >> ~/.bash_aliases


### PR DESCRIPTION
The `px4-time.service` was running before the system time has been synced. I added the dependency `time-sync.target` as well as enabled the `systemd-time-wait-sync.service` from the **setup.sh**

Right now this service just gets the time close enough (2 seconds off) so that the logs are properly timestamped. In the future I will add  TIMESYNC mavlink service
https://mavlink.io/en/services/timesync.html