### PR TITLE
[services] Bind logloader to mavlink-router

### DIFF
--- a/scripts/flash_px4.sh
+++ b/scripts/flash_px4.sh
@@ -1,22 +1,14 @@
 #!/bin/bash
-#FW_PATH=/tmp/ark_fmu-v6x_default.px4
 
-# get firmware from command line
-FW_PATH=$1
-
-# exit if no firmware path is given
-if [ -z "$FW_PATH" ]; then
-    echo "No firmware path given"
-    exit 1
-fi
+DEFAULT_FW_PATH=/tmp/ark_fmu-v6x_default.px4
+FW_PATH=${1:-$DEFAULT_FW_PATH}
 
 echo "Flashing firmware: $FW_PATH"
 
 SERIALDEVICE=$(ls -l /dev/serial/by-id/*ARK* | awk -F'/' '{print "/dev/"$NF}')
 
-# if it fails to find the ARKV6X quit the script
 if [ $? -ne 0 ]; then
-    echo "ARKV6X not found, quitting"
+    echo "ARKV6X not found, exiting"
     exit 1
 fi
 echo $SERIALDEVICE
@@ -24,4 +16,4 @@ echo $SERIALDEVICE
 sudo systemctl stop mavlink-router
 python3 /usr/bin/reset_fmu_wait_bl.py
 python3 /usr/bin/px_uploader.py --port $SERIALDEVICE $FW_PATH
-sudo systemctl start mavlink-router
+sudo systemctl start mavlink-router logloader.service

--- a/scripts/flash_px4.sh
+++ b/scripts/flash_px4.sh
@@ -5,6 +5,11 @@ FW_PATH=${1:-$DEFAULT_FW_PATH}
 
 echo "Flashing firmware: $FW_PATH"
 
+if [ ! -f "$FW_PATH" ]; then
+    echo "Firmware file does not exist, exiting"
+    exit 1
+fi
+
 SERIALDEVICE=$(ls -l /dev/serial/by-id/*ARK* | awk -F'/' '{print "/dev/"$NF}')
 
 if [ $? -ne 0 ]; then

--- a/services/logloader.service
+++ b/services/logloader.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Automatic ulog download and upload
 Wants=network.target
-Requires=mavlink-router.service
+BindsTo=mavlink-router.service
 After=syslog.target network.target mavlink-router.service
+PartOf=mavlink-router.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
A stop/restart of **mavlink-router.service** will now cause a stop/restart of **logloader.service**. It does not however couple the starting of the services, hence we need to start logloader again after flashing the PX4 binary.

See definitions for PartOf and BindsTo
https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html

Also added default value for FW_PATH arg in the **flash_px4.sh** script as well as a check that the file exists.